### PR TITLE
Handle case insensitive AudioFileName

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -431,7 +431,12 @@ namespace AudicaConverter
             Directory.CreateDirectory(tempDirectory);
 
             ZipArchive zip = ZipFile.OpenRead(osz.oszFilePath);
-            zip.GetEntry(audioFileName).ExtractToFile(tempAudioPath);
+            foreach (ZipArchiveEntry entry in zip.Entries) {
+                // Check for the name while ignoring case, as osu ignores case as well.
+                if (entry.FullName.Equals(audioFileName, StringComparison.OrdinalIgnoreCase)) {
+                    zip.GetEntry(entry.FullName).ExtractToFile(tempAudioPath);
+                }
+            }
 
             Process ffmpeg = new Process();
             ffmpeg.StartInfo.FileName = Path.Join(Program.workingDirectory, Program.FfmpegName);


### PR DESCRIPTION
The `AudioFilename` in the `[General]` section of an osu map is case insensitive. This checks the for the name in the zip archive while ignoring case. Resolves https://github.com/octoberU/AudicaConverter/issues/1